### PR TITLE
Add an option to display Scroll Lock.

### DIFF
--- a/package/contents/code/logic.js
+++ b/package/contents/code/logic.js
@@ -27,11 +27,22 @@ var keyInformation = {
 
 		isPressed: false,
 	},
+	"Scroll Lock": {
+		visibilityConfigKey: "ShowScrollLock",
+		colorConfigKey: "ScrollLockColor",
+
+		sortIndex: 2,
+
+		name: "Scrl",
+		symbol: "⇳",
+
+		isPressed: false,
+	},
 	"Shift": {
 		visibilityConfigKey: "ShowShiftPressed",
 		colorConfigKey: "ShiftPressedColor",
 
-		sortIndex: 2,
+		sortIndex: 3,
 
 		name: "Shift",
 		symbol: "⇧",
@@ -42,7 +53,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowCtrlPressed",
 		colorConfigKey: "CtrlPressedColor",
 
-		sortIndex: 3,
+		sortIndex: 4,
 
 		name: "Ctrl",
 		symbol: "^",
@@ -53,7 +64,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowMetaPressed",
 		colorConfigKey: "MetaPressedColor",
 
-		sortIndex: 4,
+		sortIndex: 5,
 
 		name: "Meta",
 		symbol: "⚑",
@@ -64,7 +75,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowSuperPressed",
 		colorConfigKey: "SuperPressedColor",
 
-		sortIndex: 5,
+		sortIndex: 6,
 
 		name: "Super",
 		symbol: "⚑",
@@ -75,7 +86,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowHyperPressed",
 		colorConfigKey: "HyperPressedColor",
 
-		sortIndex: 6,
+		sortIndex: 7,
 
 		name: "Hyper",
 		symbol: "⚑",
@@ -86,7 +97,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowAltPressed",
 		colorConfigKey: "AltPressedColor",
 
-		sortIndex: 7,
+		sortIndex: 8,
 
 		name: "Alt",
 		symbol: "⎇",
@@ -97,7 +108,7 @@ var keyInformation = {
 		visibilityConfigKey: "ShowAltGrPressed",
 		colorConfigKey: "AltGrPressedColor",
 
-		sortIndex: 8,
+		sortIndex: 9,
 
 		name: "AltGr",
 		symbol: "_",

--- a/package/contents/code/logic.js
+++ b/package/contents/code/logic.js
@@ -23,7 +23,7 @@ var keyInformation = {
 		sortIndex: 1,
 
 		name: "Caps",
-		symbol: "⬇",
+		symbol: "⇪",
 
 		isPressed: false,
 	},

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -12,6 +12,9 @@
 		<entry name="CapsLockColor" type="Color">
 			<default>red</default>
 		</entry>
+		<entry name="ScrollLockColor" type="Color">
+			<default>blue</default>
+		</entry>
 		<entry name="ShiftPressedColor" type="Color">
 			<default>#887422</default>
 		</entry>
@@ -58,6 +61,9 @@
 			<default>true</default>
 		</entry>
 		<entry name="ShowCapsLock" type="Bool">
+			<default>true</default>
+		</entry>
+		<entry name="ShowScrollLock" type="Bool">
 			<default>true</default>
 		</entry>
 		<entry name="ShowCtrlPressed" type="Bool">

--- a/package/contents/ui/config/KeysPage.qml
+++ b/package/contents/ui/config/KeysPage.qml
@@ -9,6 +9,7 @@ Item {
 
 	property alias cfg_ShowNumLock: checkBoxNumLock.checked
 	property alias cfg_ShowCapsLock: checkBoxCapsLock.checked
+	property alias cfg_ShowScrollLock: checkBoxScrollLock.checked
 	property alias cfg_ShowShiftPressed: checkBoxShiftPressed.checked
 	property alias cfg_ShowCtrlPressed: checkBoxCtrlPressed.checked
 	property alias cfg_ShowMetaPressed: checkBoxMetaPressed.checked
@@ -20,6 +21,7 @@ Item {
 
 	property alias cfg_NumLockColor: colorSelectorNumLock.color
 	property alias cfg_CapsLockColor: colorSelectorCapsLock.color
+	property alias cfg_ScrollLockColor: colorSelectorScrollLock.color
 	property alias cfg_ShiftPressedColor: colorSelectorShiftPressed.color
 	property alias cfg_CtrlPressedColor: colorSelectorCtrlPressed.color
 	property alias cfg_MetaPressedColor: colorSelectorMetaPressed.color
@@ -48,6 +50,15 @@ Item {
 
 		KeyStateComponents.ColorSelector {
 			id: colorSelectorCapsLock
+		}
+
+		QtControls.CheckBox {
+			id: checkBoxScrollLock
+			text: i18n("Scroll Lock")
+		}
+
+		KeyStateComponents.ColorSelector {
+			id: colorSelectorScrollLock
 		}
 
 		QtControls.CheckBox {


### PR DESCRIPTION
The keystate plasmoid is missing an indicator for Scroll Lock. This pull request adds support for it.

Note that for whatever reason, X.org fails to properly enable support for Scroll Lock by default. A workaround is available at https://bugs.freedesktop.org/show_bug.cgi?id=94226 :

```
xmodmap -e "add mod3 = Scroll_Lock"
```

This PR also changes the Caps Lock symbol from '⬇' to '⇪', which is a more common symbol for Caps Lock.

I didn't update images/keystate.svg, since I'm not sure exactly what goes in there.
